### PR TITLE
ci: explicitly use bash publish

### DIFF
--- a/pub.sh
+++ b/pub.sh
@@ -38,7 +38,10 @@ for PKG in "${pkgs[@]}"; do
     exit 1;
   fi
 
+  # enforce the bash impl of publish to avoid breakage with https://github.com/flox/flox/pull/197
+  # TODO: migrate to new publish command
   $FLOX                                                                  \
+     --bash-passthru                                                     \
       --stability unstable                                               \
       publish                                                            \
       --attr "packages.$SYSTEM.$PKG"                                     \


### PR DESCRIPTION
Flox publish changes with flox/flox#197
As that is not a drop in replacement for the current `flox publish` (catalogs on separate branches), for a migratory period we need to explicitly use the bash impl